### PR TITLE
Keep location hash on redirection

### DIFF
--- a/jq/download/index.html
+++ b/jq/download/index.html
@@ -3,6 +3,6 @@
 <title>Redirecting to jqlang.github.io</title>
 <link rel="canonical" href="https://jqlang.github.io/jq/download/">
 <script>
-window.location.replace("https://jqlang.github.io/jq/download")
+window.location.replace("https://jqlang.github.io/jq/download/" + location.hash);
 </script>
 <noscript><meta http-equiv="refresh" content="0; url=https://jqlang.github.io/jq/download/"></noscript>

--- a/jq/index.html
+++ b/jq/index.html
@@ -3,7 +3,7 @@
 <title>Redirecting to jqlang.github.io</title>
 <link rel="canonical" href="https://jqlang.github.io/jq/">
 <script>
-window.location.replace("https://jqlang.github.io/jq")
+window.location.replace("https://jqlang.github.io/jq/" + location.hash);
 </script>
 <noscript><meta http-equiv="refresh" content="0; url=https://jqlang.github.io/jq/"></noscript>
 

--- a/jq/index/index.html
+++ b/jq/index/index.html
@@ -3,6 +3,6 @@
 <title>Redirecting to jqlang.github.io</title>
 <link rel="canonical" href="https://jqlang.github.io/jq/index/">
 <script>
-window.location.replace("https://jqlang.github.io/jq")
+window.location.replace("https://jqlang.github.io/jq/" + location.hash);
 </script>
 <noscript><meta http-equiv="refresh" content="0; url=https://jqlang.github.io/jq/index/"></noscript>

--- a/jq/manual/index.html
+++ b/jq/manual/index.html
@@ -3,6 +3,6 @@
 <title>Redirecting to jqlang.github.io</title>
 <link rel="canonical" href="https://jqlang.github.io/jq/manual/">
 <script>
-window.location.replace("https://jqlang.github.io/jq/manual")
+window.location.replace("https://jqlang.github.io/jq/manual/" + location.hash);
 </script>
 <noscript><meta http-equiv="refresh" content="0; url=https://jqlang.github.io/jq/manual/"></noscript>

--- a/jq/manual/v1.3/index.html
+++ b/jq/manual/v1.3/index.html
@@ -3,6 +3,6 @@
 <title>Redirecting to jqlang.github.io</title>
 <link rel="canonical" href="https://jqlang.github.io/jq/manual/v1.3/">
 <script>
-window.location.replace("https://jqlang.github.io/jq/manual/v1.3")
+window.location.replace("https://jqlang.github.io/jq/manual/v1.3/" + location.hash);
 </script>
 <noscript><meta http-equiv="refresh" content="0; url=https://jqlang.github.io/jq/manual/v1.3/"></noscript>

--- a/jq/manual/v1.4/index.html
+++ b/jq/manual/v1.4/index.html
@@ -3,6 +3,6 @@
 <title>Redirecting to jqlang.github.io</title>
 <link rel="canonical" href="https://jqlang.github.io/jq/manual/v1.4/">
 <script>
-window.location.replace("https://jqlang.github.io/jq/manual/v1.4")
+window.location.replace("https://jqlang.github.io/jq/manual/v1.4/" + location.hash);
 </script>
 <noscript><meta http-equiv="refresh" content="0; url=https://jqlang.github.io/jq/manual/v1.4/"></noscript>

--- a/jq/manual/v1.5/index.html
+++ b/jq/manual/v1.5/index.html
@@ -3,6 +3,6 @@
 <title>Redirecting to jqlang.github.io</title>
 <link rel="canonical" href="https://jqlang.github.io/jq/manual/v1.5/">
 <script>
-window.location.replace("https://jqlang.github.io/jq/manual/v1.5")
+window.location.replace("https://jqlang.github.io/jq/manual/v1.5/" + location.hash);
 </script>
 <noscript><meta http-equiv="refresh" content="0; url=https://jqlang.github.io/jq/manual/v1.5/"></noscript>

--- a/jq/manual/v1.6/index.html
+++ b/jq/manual/v1.6/index.html
@@ -3,6 +3,6 @@
 <title>Redirecting to jqlang.github.io</title>
 <link rel="canonical" href="https://jqlang.github.io/jq/manual/v1.6/">
 <script>
-window.location.replace("https://jqlang.github.io/jq/manual/v1.6")
+window.location.replace("https://jqlang.github.io/jq/manual/v1.6/" + location.hash);
 </script>
 <noscript><meta http-equiv="refresh" content="0; url=https://jqlang.github.io/jq/manual/v1.6/"></noscript>

--- a/jq/tutorial/index.html
+++ b/jq/tutorial/index.html
@@ -3,6 +3,6 @@
 <title>Redirecting to jqlang.github.io</title>
 <link rel="canonical" href="https://jqlang.github.io/jq/tutorial/">
 <script>
-window.location.replace("https://jqlang.github.io/jq/tutorial")
+window.location.replace("https://jqlang.github.io/jq/tutorial/" + location.hash);
 </script>
 <noscript><meta http-equiv="refresh" content="0; url=https://jqlang.github.io/jq/tutorial/"></noscript>


### PR DESCRIPTION
As title says, this PR fixes the location hash on redirection to jqlang. We need to keep URLs like https://stedolan.github.io/jq/manual/#Math to jump to the correct anchor in jqlang page. Also, since URLs without the trailing slash responds 301 with the trailing slash, I fixed them too.